### PR TITLE
fix: jouer un son au démarrage de la scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,14 +13,14 @@
 </head>
 
 <body>
-    
-    
+
+
     <script type="text/javascript">
 
         var config = {
             type: Phaser.AUTO,
-            width: 1280 ,
-            height: 1080 ,
+            width: 1280,
+            height: 1080,
             physics: {
                 default: 'arcade',
                 arcade: {
@@ -35,7 +35,7 @@
             }
         };
 
-       
+
         var player;
         var stars;
         var bombs;
@@ -49,20 +49,23 @@
         var game = new Phaser.Game(config);
 
         function preload() {
-            this.load.audio('background', 'assets/jeu.mp3')
-            this.load.image('background', 'assets/background.png');
-            this.load.image('ground', 'assets/Platforme.png');
-            this.load.image('star', 'assets/star.png');
-            this.load.image('bomb', 'assets/bomb.png');
-            this.load.spritesheet('dude', 'assets/dude.png', { frameWidth: 32, frameHeight: 48 });
-            this.load.image('J', 'assets/j.png');
-            this.load.audio('background', 'assets/jeu.mp3');
+            this.load.image('background', 'assets/image/background.png');
+            this.load.image('ground', 'assets/image/Platforme.png');
+            this.load.image('star', 'assets/image/star.png');
+            this.load.image('bomb', 'assets/image/bomb.png');
+            this.load.spritesheet('dude', 'assets/image/dude.png', { frameWidth: 32, frameHeight: 48 });
+            this.load.image('J', 'assets/image/j.png');
+
+            // Pré-charger le son:
+            this.load.audio('sound', 'assets/sons/jeu.mp3');
         }
 
         function create() {
-            var musique_de_fond;
+
+            // Lancer le son:
+            var musique_de_fond = this.sound.add('sound');
             musique_de_fond.play();
-            
+
             this.add.image(900, 250, 'background');
 
             platforms = this.physics.add.staticGroup();
@@ -77,12 +80,12 @@
             platforms.create(200, 115, 'ground');
             platforms.create(650, 200, 'ground');
             platforms.create(1800, 650, 'J');
-            
+
             player = this.physics.add.sprite(100, 450, 'dude');
 
             player.setBounce(0.2);
             player.setCollideWorldBounds(true);
-            
+
 
 
 
@@ -133,17 +136,10 @@
             this.physics.add.overlap(player, stars, collectStar, null, this);
 
             this.physics.add.collider(player, bombs, hitBomb, null, this);
-            
-            musique_de_fond.play();
-        
-            var musique_de_fond
-        
-            musique_de_fond = this.sound.add('background');
-       
-}
+        }
 
         function update() {
-            
+
             if (gameOver) {
                 return;
             }
@@ -191,13 +187,12 @@
                 bomb.setCollideWorldBounds(true);
                 bomb.setVelocity(Phaser.Math.Between(-200, 200), 20);          // config des bombes
                 bomb.allowGravity = false;
-            
+
 
             }
         }
 
-        function hitBomb(player, bomb) 
-        {
+        function hitBomb(player, bomb) {
             this.physics.pause();
 
             player.setTint(0xff0000);
@@ -208,10 +203,10 @@
             location.reload()
             this.game.reload()
         }
-      
-  
 
-</script>
+
+
+    </script>
 
 </body>
 


### PR DESCRIPTION
## Modifications

- Chargement des ressources: Dans la fonction `preload`, j'ai mis à jour les chemins d'accès aux images et aux fichiers audio. Les nouvelles URL pointent vers les ressources situées dans les répertoires `assets/image` et `assets/sons`, respectivement.

- Intégration du son: J'ai ajouté une fonctionnalité audio en utilisant Phaser. J'ai chargé le fichier audio `jeu.mp3` dans la fonction `preload` à l'aide de la méthode `this.load.audio`. Ensuite, dans la fonction `create`, j'ai créé un objet sonore en utilisant la méthode `this.sound.add` et je l'ai assigné à la variable `musique_de_fond`. J'ai ensuite lancé la lecture du son en appelant la méthode `play()` sur cet objet sonore.

- Image de fond: J'ai modifié le chemin d'accès à l'image de fond pour qu'il pointe vers `assets/image/background.png`.

💡:wave: